### PR TITLE
parallelisation of GMRC evaluation

### DIFF
--- a/gtracr/tests/test_gmrc.py
+++ b/gtracr/tests/test_gmrc.py
@@ -1,21 +1,53 @@
 import time
-from gtracr.geomagnetic_cutoffs import GMRC
+import sys
+import numpy as np
+from p_tqdm import p_map
+from gtracr.plotting import plot_gmrc_heatmap
 
-# default GMRC at Kamioka
-gmrc_serial = GMRC()
+# using the local GMRC class instead of from the package
+sys.path.append("..")
+from geomagnetic_cutoffs import GMRC
 
-start = time.time()
-gmrc_serial.evaluate()
-end = time.time()
+# a main guard is required to be multiprocessing safe in Windows
+# see eg. https://stackoverflow.com/questions/20360686/compulsory-usage-of-if-name-main-in-windows-while-using-multiprocessi
+if __name__ == "__main__":
 
-print("GMRC serial evaluated in", end - start, "secs")
+    # default GMRC at Kamioka
+    gmrc_serial = GMRC(iter_num= 5000)
 
-interpd_gmrc_data = gmrc_serial.interpolate_results()
+    start = time.time()
+    gmrc_serial.evaluate()
+    end = time.time()
 
-plot_gmrc_heatmap(interpd_gmrc_data,
-                  gmrc_serial.rigidity_list,
-                  locname=gmrc_serial.location,
-                  plabel=gmrc_serial.plabel,
-                  bfield_type = '',
-                  show_plot = True,
-                  plotdir_path = '')
+    print("GMRC serial evaluated in", end - start, "secs")
+
+    interpd_gmrc_data = gmrc_serial.interpolate_results()
+
+    plot_gmrc_heatmap(interpd_gmrc_data,
+                      gmrc_serial.rigidity_list,
+                      locname=gmrc_serial.location,
+                      plabel=gmrc_serial.plabel,
+                      bfield_type = '',
+                      show_plot = True,
+                      plotdir_path = '')
+
+    gmrc_parallel = GMRC(iter_num = 5000, method='parallel')
+
+    start = time.time()
+    # azimuth = np.random.rand(gmrc_parallel.iter_num) * 360.0
+    # zenith = np.random.rand(gmrc_parallel.iter_num) * 180.0
+    # rigidity = p_map(gmrc_parallel.evaluate_angle, azimuth, zenith)
+    gmrc_parallel.evaluate()
+    end = time.time()
+
+    print("GMRC parallel evaluated in", end - start, "secs")
+
+    interpd_gmrc_data = gmrc_parallel.interpolate_results()
+
+    plot_gmrc_heatmap(interpd_gmrc_data,
+                    gmrc_parallel.rigidity_list,
+                    locname=gmrc_parallel.location,
+                    plabel=gmrc_parallel.plabel,
+                    bfield_type = '',
+                    show_plot = True,
+                    plotdir_path = '')

--- a/gtracr/tests/test_gmrc.py
+++ b/gtracr/tests/test_gmrc.py
@@ -1,0 +1,21 @@
+import time
+from gtracr.geomagnetic_cutoffs import GMRC
+
+# default GMRC at Kamioka
+gmrc_serial = GMRC()
+
+start = time.time()
+gmrc_serial.evaluate()
+end = time.time()
+
+print("GMRC serial evaluated in", end - start, "secs")
+
+interpd_gmrc_data = gmrc_serial.interpolate_results()
+
+plot_gmrc_heatmap(interpd_gmrc_data,
+                  gmrc_serial.rigidity_list,
+                  locname=gmrc_serial.location,
+                  plabel=gmrc_serial.plabel,
+                  bfield_type = '',
+                  show_plot = True,
+                  plotdir_path = '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ datetime
 pytest
 pytest-cov
 tqdm
+p_tqdm


### PR DESCRIPTION
A slight refactoring of the GMRC class to allow (CPU) parallel evaluation of the geomagnetic rigidity cutoff. (Issue #8)

The example multiprocessing is handled by the p_tqdm library which uses pathos.multiprocessing and tqdm. Some functionality from gtracr.trajectory has been moved up to GMRC to allow for eg. arbitrary locations and detector altitudes. If the location name is specified, it will override these for the locations in the location_dict.

A test script compares the serial and parallel GMRC.evaluate() versions. The p_map version is about 2.5x faster on my machine, there are probably a lot more optimisations to be had (eg. p_umap).

